### PR TITLE
Proper clientside testing of IBAN number

### DIFF
--- a/app/assets/javascripts/stripe_form.js
+++ b/app/assets/javascripts/stripe_form.js
@@ -43,7 +43,7 @@ window.ST.stripe_form_i18n = {
       separator: "-"
     },
     DK: {
-      account_number: {title: 'IBAN', format: 'DK5000400440116243', regexp: 'DK[0-9]{2}[0-9]{14}', test_regexp: 'DK'+TEST_IBAN }
+      account_number: {title: 'IBAN', format: 'DK5000400440116243', regexp: 'DK[0-9]{2}[0-9]{14}', test_regexp: 'DK[0-9]{2}[0-9]{14}' }
     },
     FI: {
       account_number: {title: 'IBAN', format: 'FI2112345600000785', regexp: 'FI[0-9]{2}[0-9]{14}', test_regexp: 'FI'+TEST_IBAN }


### PR DESCRIPTION
The previous clientside test regex is very much a placeholder test with a very specific expectation,
which will fail in any realistic scenario. This seems to be the case with many other countries,
but for now we are only fixing DK.