### PR TITLE
Create and edit working date slots

### DIFF
--- a/app/controllers/working_date_slots_controller.rb
+++ b/app/controllers/working_date_slots_controller.rb
@@ -1,0 +1,43 @@
+class WorkingDateSlotsController < ApplicationController
+  def index
+    @working_date_slots = @current_user.working_date_slots
+    @working_date_slot = Listing::WorkingDateSlot.new
+  end
+
+  def create
+    @working_date_slot = Listing::WorkingDateSlot.new(working_date_params)
+
+    if @working_date_slot.save
+      return redirect_to(working_date_slots_path)
+    else
+      @working_date_slots = @current_user.working_date_slots
+      render :index
+    end
+  end
+
+  def edit
+    @working_date_slot = @current_user.working_date_slots.find(params[:id])
+  end
+
+  def update
+    @working_date_slot = @current_user.working_date_slots.find(params[:id])
+    if @working_date_slot.update(working_date_params)
+      redirect_to(working_date_slots_path)
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def working_date_params
+    params.
+      require(:listing_working_date_slot).
+      permit(
+        :date,
+        :from,
+        :person_id,
+        :till
+      )
+  end
+end

--- a/app/presenters/working_date_slot_presenter.rb
+++ b/app/presenters/working_date_slot_presenter.rb
@@ -1,0 +1,11 @@
+class WorkingDateSlotPresenter < MemoisticPresenter
+  include ListingAvailabilityManage
+
+  def time_slot_options
+    (0..24).map do |x|
+      value = format("%02d:00", x)
+      name = I18n.locale == :en ? Time.parse("#{x}:00").strftime("%l:00 %P") : value # rubocop:disable Rails/TimeZone
+      [name, value]
+    end
+  end
+end

--- a/app/presenters/working_date_slot_presenter.rb
+++ b/app/presenters/working_date_slot_presenter.rb
@@ -1,6 +1,4 @@
 class WorkingDateSlotPresenter < MemoisticPresenter
-  include ListingAvailabilityManage
-
   def time_slot_options
     (0..24).map do |x|
       value = format("%02d:00", x)

--- a/app/views/listings/_listing_actions.haml
+++ b/app/views/listings/_listing_actions.haml
@@ -141,10 +141,10 @@
         - availability_link_id = "edit-listing-availability-#{SecureRandom.urlsafe_base64(5)}"
         .listing-view-admin-link
           - if @listing_presenter.booking_per_hour?
-            %a.icon-with-text-container{id: availability_link_id, href: "#manage-working-hours"}
+            .icon-with-text-container{id: availability_link_id, href: "#manage-working-hours"}
               = icon_tag("calendar", ["icon-part"])
-              .text-part= t("web.listings.edit_listing_availability")
-            = react_component("ListingWorkingHoursApp", props: @listing_presenter.working_hours_props.merge({ availability_link_id: availability_link_id }), prerender: false)
+              .text-part
+                = link_to(translate("web.listings.edit_listing_availability"), working_date_slots_path)
           - elsif APP_CONFIG.harmony_api_in_use
             %a.icon-with-text-container{id: availability_link_id, href: "#manage-availability"}
               = icon_tag("calendar", ["icon-part"])

--- a/app/views/working_date_slots/_inputs.html.haml
+++ b/app/views/working_date_slots/_inputs.html.haml
@@ -1,0 +1,23 @@
+- date_slot_presenter = WorkingDateSlotPresenter.new
+
+= form.hidden_field :person_id, :value => current_user.id
+- if working_date_slot.errors.present?
+  %p.new-marketplace-errors
+    = working_date_slot.errors.full_messages.join('<br />').html_safe
+
+.input-daterange.input-group.clearfix
+  .datepicker-per-hour
+    .row
+      .field
+        = form.label :date
+        = form.date_field :date, :id => "start_on", :data => {:locale => I18n.locale}, :class => "input-sm form-control required"
+    .row
+      .field
+        = form.label :from
+        = form.select :from, options_for_select(date_slot_presenter.time_slot_options, working_date_slot.from, ), {}, :id => "start_time"
+    .row
+      .field
+        = form.label :till
+        = form.select :till, options_for_select(date_slot_presenter.time_slot_options, working_date_slot.till), {}, :id => "end_time"
+
+  = form.submit(translate(".submit"), :class => "enabled-book-button")

--- a/app/views/working_date_slots/edit.html.haml
+++ b/app/views/working_date_slots/edit.html.haml
@@ -1,0 +1,6 @@
+- date_slot_presenter = WorkingDateSlotPresenter.new
+
+.row
+  .col-8.listing-details-container
+    = form_for(@working_date_slot, :url => working_date_slot_path(@working_date_slot), :method => :patch) do |form|
+      = render :partial => "inputs", :locals => {:form => form, :working_date_slot => @working_date_slot, :current_user => @current_user}

--- a/app/views/working_date_slots/index.html.haml
+++ b/app/views/working_date_slots/index.html.haml
@@ -1,0 +1,28 @@
+.row
+  - date_slot_presenter = WorkingDateSlotPresenter.new
+
+  .col-8.listing-details-container
+    %table
+      %thead
+        %th= translate(".date")
+        %th= translate(".from")
+        %th= translate(".till")
+        %th= translate(".actions")
+      %tbody
+        - @working_date_slots.each do |slot|
+          %tr
+            %td
+              = localize(slot.date)
+            %td
+              = slot.from
+            %td
+              = slot.till
+            %td
+              = link_to(translate(".edit"), edit_working_date_slot_path(slot))
+
+  .col-4
+    .row-with-divider
+      .col-12
+        .listing-message-links
+          = form_for(@working_date_slot, :url => working_date_slots_path) do |form|
+            = render :partial => "inputs", :locals => {:form => form, :working_date_slot => @working_date_slot, :current_user => @current_user}

--- a/app/views/working_date_slots/index.html.haml
+++ b/app/views/working_date_slots/index.html.haml
@@ -1,6 +1,6 @@
-.row
-  - date_slot_presenter = WorkingDateSlotPresenter.new
+- date_slot_presenter = WorkingDateSlotPresenter.new
 
+.row
   .col-8.listing-details-container
     %table
       %thead

--- a/config/locales/da-DK.yml
+++ b/config/locales/da-DK.yml
@@ -2832,3 +2832,13 @@ da-DK:
       category_description: ~
       profile_title: ~
       profile_description: ~
+
+  working_date_slots:
+    inputs:
+      submit: "Opret tid på dato"
+    index:
+      date: "Dato"
+      from: "Fra kl."
+      till: "Til kl."
+      actions: "handlinger"
+      edit: "Rediger"

--- a/config/locales/da-DK.yml
+++ b/config/locales/da-DK.yml
@@ -1493,6 +1493,7 @@ da-DK:
       on_or_after: "skal være på eller efter %{restriction}"
       positive_number: "Indsæt et tal."
       from_must_be_less_than_till: "\"Starttidspunkt\" skal være tidligere end \"Sluttidspunkt\""
+      conflicts_with_other: "Der er en konflikt med en eksisterende tidsperiode for samme dato."
   event_feed_events:
     accept:
       has_accepted_lend_item: "%{offerer_name} indvilligede i at udlåne %{listing_title} til %{requester_name}%{time_ago}"

--- a/config/locales/da-DK.yml
+++ b/config/locales/da-DK.yml
@@ -1,4 +1,10 @@
 da-DK:
+  activerecord:
+    attributes:
+      listing/working_date_slot:
+        date: "Dato"
+        from: "Fra"
+        till: "Til"
   number:
     currency:
       format:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,10 @@
 en:
+  activerecord:
+    attributes:
+      listing/working_date_slot:
+        date: "Date"
+        from: "From"
+        till: "To"
   number:
     currency:
       format:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1499,6 +1499,7 @@ en:
       on_or_after: "must be on or after %{restriction}"
       positive_number: "Insert a number."
       from_must_be_less_than_till: "\"Start time\" must be less than \"End time\""
+      conflicts_with_other: "Conflics with existing time period for same date."
   event_feed_events:
     accept:
       has_accepted_lend_item: "%{offerer_name} agreed to lend %{listing_title} to %{requester_name} %{time_ago}."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -363,6 +363,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :working_date_slots, :only => [:index, :create, :edit, :update]
+
     resources :listings do
       member do
         post :follow


### PR DESCRIPTION
Enables creating and editing working date slots, that does not overlap eachother

## WorkingDateSlots#index
![Screenshot 2019-05-23 at 10 00 00](https://user-images.githubusercontent.com/5213037/58235663-8fc66180-7d41-11e9-9d56-116bf4d2c52f.png)

## WorkingDateSlots#edit
![Screenshot 2019-05-23 at 10 00 37](https://user-images.githubusercontent.com/5213037/58235699-a2409b00-7d41-11e9-9708-7af85e22ab07.png)
