### PR TITLE
Manage availability directly from menu

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -599,7 +599,8 @@ class ApplicationController < ActionController::Base
           "feedback",
           "invite",
           "redirect",
-          "admin"
+          "admin",
+          "calendar"
         ])
     }
 

--- a/app/views/layouts/_header_user_menu.haml
+++ b/app/views/layouts/_header_user_menu.haml
@@ -16,6 +16,10 @@
     = icon_map_tag(icons, "list", ["icon-with-text"])
     = t("header.manage_listings")
 
+  = link_to working_date_slots_path do
+    = icon_map_tag(icons, "calendar", ["icon-with-text"])
+    = t("header.manage_availability")
+
   = link_to settings_path do
     = icon_map_tag(icons, "settings", ["icon-with-text"])
     = t("layouts.logged_in.settings")

--- a/app/views/working_date_slots/index.html.haml
+++ b/app/views/working_date_slots/index.html.haml
@@ -1,5 +1,9 @@
 - date_slot_presenter = WorkingDateSlotPresenter.new
 
+- content_for :title_header do
+  %h1
+    %span.profile-title= translate("layouts.no_tribe.availability")
+
 .row
   .col-8.listing-details-container
     %table

--- a/config/locales/da-DK.yml
+++ b/config/locales/da-DK.yml
@@ -1537,6 +1537,7 @@ da-DK:
     create_new_marketplace: "Opret en ny markedsplads"
     contact_us: "Kontakt os"
     profile: Profil
+    manage_availability: "Opdater tilgængelighed"
     manage_listings: "Administrer annoncer"
     invite: "Referer til ven"
     login: "Log ind"

--- a/config/locales/da-DK.yml
+++ b/config/locales/da-DK.yml
@@ -1674,6 +1674,7 @@ da-DK:
       create_own: "Vil du oprette din egen online markedsplads hjemmeside som %{learn_more} %{service_name}"
       learn_more: "Lær mere"
     no_tribe:
+      availability: "Tilgængelighed"
       inbox: Indbakke
       settings: Indstillinger
       feedback: "Kontakt %{service_name} team"


### PR DESCRIPTION
There's no need to go through a listing to manage general availability.

![Screenshot 2019-07-25 10 47 55](https://user-images.githubusercontent.com/6480/61861423-2e02af00-aecc-11e9-970e-df8b5f611af3.png)

Closes #34 