### PR TITLE
Don't talk about using external email client to invite

### DIFF
--- a/app/views/invitations/new.haml
+++ b/app/views/invitations/new.haml
@@ -11,8 +11,6 @@
 #invitation_form.centered-section
   - support_link = link_to(t("homepage.invitation_form.this_article_link"), "https://help.sharetribe.com/configuration-and-how-to/how-to-send-mass-emails-and-invitations", target: "_blank")
   %p= t("homepage.invitation_form.add_email_addresses_description")
-  - if has_admin_rights
-    %p= t("homepage.invitation_form.add_lots_of_email_addresses", this_article_link: support_link).html_safe
   = form_for Invitation.new, :url => invitations_path do |f|
     = f.label :email, t("homepage.invitation_form.email")
     = f.text_area :email, :class => "text_field", :placeholder => t("homepage.invitation_form.invitation_emails_field_placeholder")


### PR DESCRIPTION
I've removed the text talking about sending many invites. Probably pointless, though, that bit of text was only shown to admins anyways ;)

Closes #47 